### PR TITLE
Ensure netlink messages' buffer has correct alignment before parsing.

### DIFF
--- a/nfnl_sock.go
+++ b/nfnl_sock.go
@@ -190,7 +190,9 @@ func (s *NetlinkSocket) RecvErr() error {
 }
 
 // receive reads from the socket, parses messages, and writes each parsed message
-// to the recvChan channel.  It will loop reading and processing messages until an
+// to the recvChan channel. The received buffer is aligned to NLMSG_ALIGNTO before
+// parsing.
+// It will loop reading and processing messages until an
 // error occurs and then return the error.
 func (s *NetlinkSocket) receive() error {
 	for {
@@ -198,7 +200,7 @@ func (s *NetlinkSocket) receive() error {
 		if err != nil {
 			return err
 		}
-		msgs, err := syscall.ParseNetlinkMessage(s.recvBuffer[:n])
+		msgs, err := syscall.ParseNetlinkMessage(s.recvBuffer[:nlmAlignOf(n)])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Netlink requires that each message, and message part, start address is (4B) aligned.
However, there is no guarantee that the last message in a buffer is padded to the alignment.
Thus, the filled buffer may have fewer bytes than required by strict adherence to alignment,
which may cause syscall.ParseNetlinkMessage to panic as it tries to skip over the unaligned message.

The change ensures that messages passed for parsing are aligned as expected.
As the input buffer size (8192) is already correctly aligned, we are guaranteed
that the added alignment would not overflow the buffer.

Fixes #1 
Alternative to PR https://github.com/subgraph/go-nfnetlink/pull/1 by @david415